### PR TITLE
Update XCode 12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: osx
+osx_image: xcode12.2
 language: cpp
 compiler: clang
 


### PR DESCRIPTION
This PR fix the following error.

https://travis-ci.org/github/hiroyuki-sato/ucx-porting-helpers/jobs/741325617#L5844

It seems that the problems relate to the Xcode version.
The current version is `xcode9.4`

```
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I../.. -DCPU_FLAGS= -I/Users/travis/build/hiroyuki-sato/ucx-porting-helpers/scripts/ucx/src -I/Users/travis/build/hiroyuki-sato/ucx-porting-helpers/scripts/ucx -I/Users/travis/build/hiroyuki-sato/ucx-porting-helpers/scripts/ucx/src -O0 -D_DEBUG -g -Wall -Werror -fmax-type-align=16 -funwind-tables -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-label -Wno-long-long -Wno-endif-labels -Wno-sign-compare -Wno-multichar -Wno-deprecated-declarations -Winvalid-pch -Wno-pointer-sign -Werror-implicit-function-declaration -Wno-format-zero-length -Wnested-externs -Wshadow -I/Users/travis/build/hiroyuki-sato/ucx-porting-helpers/scripts/ucx/progress64/include -MT tcp/libuct_la-tcp_ep.lo -MD -MP -MF tcp/.deps/libuct_la-tcp_ep.Tpo -c tcp/tcp_ep.c  -fno-common -DPIC -o tcp/.libs/libuct_la-tcp_ep.o
5845clang: error: unable to execute command: Segmentation fault: 11
5846clang: error: clang frontend command failed due to signal (use -v to see invocation)
5847Apple LLVM version 9.1.0 (clang-902.0.39.2)
5848Target: x86_64-apple-darwin17.7.0
5849Thread model: posix
5850InstalledDir: /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
5851clang: note: diagnostic msg: PLEASE submit a bug report to http://developer.apple.com/bugreporter/ and include the crash backtrace, preprocessed source, and associated run script.
5852clang: note: diagnostic msg: 
5853********************
5854
5855PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
5856Preprocessed source(s) and associated run script(s) are located at:
5857clang: note: diagnostic msg: /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tcp_ep-376cf1.c
5858clang: note: diagnostic msg: /var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/tcp_ep-376cf1.sh
5859clang: note: diagnostic msg: Crash backtrace is located in
5860clang: note: diagnostic msg: /Users/travis/Library/Logs/DiagnosticReports/clang_<YYYY-MM-DD-HHMMSS>_<hostname>.crash
5861clang: note: diagnostic msg: (choose the .crash file that corresponds to your crash)
5862clang: note: diagnostic msg: 
5863
5864********************
5865make[1]: *** [tcp/libuct_la-tcp_ep.lo] Error 1
5866make: *** [all-recursive] Error 1
5867The command "bash ./build_mac_ucx.bash" exited with 2.
5868
5869
5870Done. Your build exited with 1.
```